### PR TITLE
don't raise NoMethodError if a bad string is assigned to a date field.

### DIFF
--- a/lib/custom_fields/types/date.rb
+++ b/lib/custom_fields/types/date.rb
@@ -21,7 +21,7 @@ module CustomFields
             def #{self.safe_alias}=(value)
               if value.is_a?(::String) && !value.blank?
                 date = ::Date._strptime(value, I18n.t('date.formats.default'))
-                value = ::Date.new(date[:year], date[:mon], date[:mday])
+                value = date ? ::Date.new(date[:year], date[:mon], date[:mday]) : nil
               end
 
               self.#{self._name} = value

--- a/spec/unit/types/date_spec.rb
+++ b/spec/unit/types/date_spec.rb
@@ -48,6 +48,12 @@ describe CustomFields::Types::Date do
       @project.self_metadata.field_1.should == @date
     end
 
+    it 'sets nil from an invalid string' do
+      @project.self_metadata.started_at = '12345'
+      @project.self_metadata.started_at.should be_nil
+      @project.self_metadata.field_1.should be_nil
+    end
+
     it 'sets value (in French format) from a string' do
       I18n.stubs(:t).returns('%d/%m/%Y')
       @project.self_metadata.started_at = '29/06/2010'


### PR DESCRIPTION
When a bad formatted string is assigned to a Date, set nil instead of raising NoMethodError on nil.[].
