### PR TITLE
Mongo 2.6 $unset error while pushing wagon

### DIFF
--- a/lib/custom_fields/source.rb
+++ b/lib/custom_fields/source.rb
@@ -175,7 +175,7 @@ module CustomFields
       # http://docs.mongodb.org/manual/reference/method/db.collection.update/#update-parameter
       # The <update> document must contain only update operator expressions.
       %w(set unset rename).each do |operation_name|
-        _operations = { "$#{operation_name}" => operations.delete("$#{operation_name}") }
+        _operations = { "$#{operation_name}" => operations.delete("$#{operation_name}") || {} }
         collection.find(selector).update _operations, multi: true
       end
     end


### PR DESCRIPTION
Thank you for all of your work on LocomotiveCMS!

I ran into this error when running `wagon push` to an environment using Mongo 2.6.x:

`{"error"=>"The operation: #<Moped::Protocol::Command\n  @length=XXXXX\n  @request_id=XXXXX\n  @response_to=0\n  @op_code=2004\n  @flags=[]\n  @full_collection_name=\"XXXXXX.$cmd\"\n  @skip=0\n  @limit=-1\n  @selector={:getlasterror=>1, :safe=>true}\n  @fields=nil>\nfailed with error 9: \"'$unset' is empty. You must specify a field like so: {$mod: {<field>: ...}}\"\n\nSee https://github.com/mongodb/mongo/blob/master/docs/errors.md\nfor details about this error."}`

Looking at the [mongodb-user Google Group](https://groups.google.com/forum/#!topic/mongodb-user/OLCofnfZu4M), it seems this is due to a newly introduced validation in Mongo 2.6 that some people are arguing is unnecessarily strict.

I see #31 which split the $set, $unset, and $rename into separate operations. However, this means it will execute each of those even if there was not originally that command. This patch only executes operations which do not have null or empty-hash values.

I do not claim this is the best solution, but it fixed my issue with `wagon push`!

P.S. For anyone using Heroku, the MongoLab AddOn uses Mongo 2.6.x for free-tier accounts.
