### PR TITLE
Update method name parents -> module_parents

### DIFF
--- a/lib/custom_fields/source.rb
+++ b/lib/custom_fields/source.rb
@@ -336,7 +336,7 @@ module CustomFields
       def declare_embedded_in_definition_in_custom_field(name)
         klass_name = self.dynamic_custom_field_class_name(name).split('::').last # Use only the class, ignore the modules
 
-        source = self.parents.size > 1 ? self.parents.first : Object
+        source = self.module_parents.size > 1 ? self.module_parents.first : Object
 
         unless source.const_defined?(klass_name)
           (klass = Class.new(::CustomFields::Field)).class_eval <<-EOF


### PR DESCRIPTION
```
DEPRECATION WARNING: `Module#parents` has been renamed to `module_parents`. `parents` is deprecated and will be removed in Rails 6.1. (called from declare_embedded_in_definition_in_custom_field at /Users/yosiyuki/.rvm/gems/ruby-2.6.6/bundler/gems/custom_fields-26c6831de9e1/lib/custom_fields/source.rb:339)
```